### PR TITLE
use bodyParser.json(), not bodyParser()

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Remember all of the crappy code we had to write to get POST data? Express and bo
 * In order to get the POST data without using .on('data') and .on('end'), we'll use bodyParser:
 
 ```javascript
-app.use(bodyParser());
+app.use(bodyParser.json());
 ```
 
 bodyParser is *middleware*, meaning it runs before every request. It automatically parses the body of requests and puts it together in a nice `req.body` property.


### PR DESCRIPTION
using bodyParser is a security vulnerability because it will auto parse `urlencoded()` which makes an app vulnerable to CSRF attacks. Since we don't have time to discuss CSRF and since angular uses JSON anyway, we should not include `bodyParse.urlencoded()`.
